### PR TITLE
mco doesn't support multiple SSH key in file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,52 +13,44 @@ github_pki is a command that can be used to retrieve and dump SSH keys from GitH
 ### Dump all keys from team `devops` in organization `zeorg` to `/home/bob/.ssh/authorized_keys`
 
 ```shell
-$ AUTHORIZED_KEYS=/home/bob/.ssh/authorized_keys \
-  GITHUB_ORG="zeorg" \
-  GITHUB_TEAM="devops" \
-  GITHUB_TOKEN=398d6d326b546d70f9e1ef91abad1fc5ee0f1f39 \
-    github_pki
+$ github_pki -a /home/bob/.ssh/authorized_keys \
+             -o "zeorg" -T "devops" \
+             -t 398d6d326b546d70f9e1ef91abad1fc5ee0f1f39
 ```
 
 ### Dump all keys from specified users as X509 public keys
 
 ```shell
-$ SSL_DIR=/etc/software/ssl \
-  GITHUB_USERS="bob,alice" \
-  GITHUB_TOKEN=398d6d326b546d70f9e1ef91abad1fc5ee0f1f39 \
-    github_pki
+$ github_pki -s /etc/software/ssl \
+             -u bob -u alice \
+             -t 398d6d326b546d70f9e1ef91abad1fc5ee0f1f39
 ```
 
 
-## Environment variables
+### Individual user format
 
-### GITHUB_TOKEN
+Individual users (`-u` or `GITHUB_USERS`) can be passed in the following format:
 
-The GitHub token used to connect to the GitHub API. It must allow two actions:
+#### Specify multiple users:
 
-- read:org
-- read:public_key
+```
+$ github_pki -u bob -u alice
+```
 
-### GITHUB_ORG
+#### Specify a different name on GitHub
 
-An organization from which to select users to authorize.
+GitHub user `bob` is called `alice` locally:
 
-### GITHUB_TEAM
 
-A team of the provided organization from which to select users to authorize.
-If not specified, all users in `GITHUB_ORG` will be authorized.
+```
+$ github_pki -u bob=alice
+```
 
-Multiple teams can be specified, separated by commas.
 
-### GITHUB_USERS
+#### Specify a key ID to use
 
-A list of GitHub users to authorize.
+```
+$ github_pki -u bob:1234
+```
 
-### AUTHORIZED_KEYS
-
-The location of the `authorized_keys` file to create.
-
-### SSL_DIR
-
-The location of the SSL directory where X509 public keys should be dumped.
 


### PR DESCRIPTION
Would be great if `GITHUB_USERS` could fill the ssh key id, in the form:

```
GITHUB_USERS="cjeanneret:id_rsa_foo"
```

Usecase: multiple SSH key in github account.
