### PR TITLE
Remove onbuild and go-wrapper from Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM golang:onbuild
-ENTRYPOINT ["go-wrapper", "run"]
-CMD [""]
+FROM golang:latest as build
+WORKDIR /go/src/app
+COPY . .
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+FROM debian:buster
+COPY --from=build /go/bin/app /
+ENTRYPOINT ["/app"]


### PR DESCRIPTION
[onbuild images](https://github.com/docker-library/official-images/issues/2076) are deprecated
[go-wrapper](https://github.com/docker-library/golang/pull/205) is deprecated